### PR TITLE
Update merged travis build to use modern ruby, use gems from gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
-# route the build to the container-based infrastructure for a faster build
-sudo: false
 language: ruby
 rvm:
-  - 2.2.5
+  - 2.5
+  - latest
 
 env:
   global:
     # speeds up installation of html-proofer
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-
-install:
-  - gem install jekyll
-  - gem install html-proofer
 
 # build and validate HTML files
 # more info at https://github.com/gjtorikian/html-proofer

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
 # build and validate HTML files
 # more info at https://github.com/gjtorikian/html-proofer
-script: jekyll build && htmlproofer ./_site --alt-ignore '/.*/'
+script: bundle exec jekyll build && bundle exec htmlproofer ./_site --alt-ignore '/.*/'
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - 2.5
-  - latest
+  - current
 
 env:
   global:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'jekyll'
+
+group :test do
+  gem 'html-proofer'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,33 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     colorator (1.1.0)
+    colorize (0.8.1)
     concurrent-ruby (1.0.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
+    ethon (0.11.0)
+      ffi (>= 1.3.0)
     eventmachine (1.2.7)
     ffi (1.9.25)
     forwardable-extended (2.6.0)
+    html-proofer (3.9.2)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colorize (~> 0.8)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.8.1)
+      parallel (~> 1.3)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -38,6 +55,11 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     mercenary (0.3.6)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
+    nokogiri (1.8.4)
+      mini_portile2 (~> 2.3.0)
+    parallel (1.12.1)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.2)
@@ -52,11 +74,18 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    thread_safe (0.3.6)
+    typhoeus (1.3.0)
+      ethon (>= 0.9.0)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    yell (2.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  html-proofer
   jekyll
 
 BUNDLED WITH


### PR DESCRIPTION
I also enabled the travis build at https://travis-ci.org/compwron/square.github.io