### PR TITLE
Update the engineering blog URL for good.

### DIFF
--- a/index.mustache
+++ b/index.mustache
@@ -97,7 +97,7 @@
               <li class="profile-module">
                 <h2 class="module-name">Join us</h2>
                 <ul class="module-list">
-                  <li><a href="http://corner.squareup.com">Engineering Blog</a> &ndash; corner.squareup.com</li>
+                  <li><a href="https://developer.squareup.com/blog/">Engineering Blog</a> &ndash; developer.squareup.com/blog</li>
                   <li><a href="https://squareup.com/careers">Careers Page</a> &ndash; squareup.com/careers</li>
                   <li class="module-social">
                     <a href="https://twitter.com/SquareEng" target="_blank"><i class="icon-twitter"></i></a>


### PR DESCRIPTION
This was originally proposed in #43, but that only updated the generated HTML file instead of the template, so will get removed the next time `./generate.py` is run.