### PR TITLE
Added Alt tags to images and added meta description to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
         <section class="profile-masthead" id="masthead">
           <header class="profile-logo">
             <div class="profile-logo-image">
-              <img alt="Square Open Source " src="/images/logo.png" />
+              <img alt="Square Open Source " src="/images/logo.png" alt="Square Open Source"/>
             </div>
             <div class="profile-name">
               <h1>Square Open Source</h1>
@@ -62,7 +62,7 @@
                   <p class="menu-item-description">Standalone Android widget for picking a single date from a calendar view.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/android-times-square.jpg" />
+                  <img src="/repo_images/android-times-square.jpg" alt="android-times-square" />
                 </div>
               </li>
               <li class="menu-item">
@@ -72,7 +72,7 @@
                   <p class="menu-item-description">A set of AssertJ helpers geared toward testing Android.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/assertj-android.jpg" />
+                  <img src="/repo_images/assertj-android.jpg" alt="assertj-android" />
                 </div>
               </li>
               <li class="menu-item">
@@ -82,7 +82,7 @@
                   <p class="menu-item-description">LeakCanary is a memory leak detection library for Android.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/leakcanary.jpg" />
+                  <img src="/repo_images/leakcanary.jpg" alt="leakcanary"/>
                 </div>
               </li>
               <li class="menu-item">
@@ -92,7 +92,7 @@
                   <p class="menu-item-description">A modern JSON library for Kotlin and Java.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/moshi.jpg" />
+                  <img src="/repo_images/moshi.jpg" alt="moshi" />
                 </div>
               </li>
               <li class="menu-item">
@@ -102,7 +102,7 @@
                   <p class="menu-item-description">An HTTP client for Android, Kotlin, and Java.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/okhttp.jpg" />
+                  <img src="/repo_images/okhttp.jpg" alt="okhttp" />
                 </div>
               </li>
               <li class="menu-item">
@@ -112,7 +112,7 @@
                   <p class="menu-item-description">A modern I/O library for Android, Kotlin, and Java.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/okio.jpg" />
+                  <img src="/repo_images/okio.jpg" alt="okio" />
                 </div>
               </li>
               <li class="menu-item">
@@ -122,7 +122,7 @@
                   <p class="menu-item-description">A powerful image downloading and caching library for Android</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/picasso.jpg" />
+                  <img src="/repo_images/picasso.jpg" alt="picasso" />
                 </div>
               </li>
               <li class="menu-item">
@@ -132,7 +132,7 @@
                   <p class="menu-item-description">Java client for the Thumbor image service which allows you to build URIs in an expressive fashion using a fluent API.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/pollexor.jpg" />
+                  <img src="/repo_images/pollexor.jpg" alt="pollexor" />
                 </div>
               </li>
               <li class="menu-item">
@@ -142,7 +142,7 @@
                   <p class="menu-item-description">Type-safe HTTP client for Android and Java by Square, Inc.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/retrofit.jpg" />
+                  <img src="/repo_images/retrofit.jpg" alt="retrofit" />
                 </div>
               </li>
               <li class="menu-item">
@@ -152,7 +152,7 @@
                   <p class="menu-item-description">Distributing instrumentation tests to all your Androids.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/spoon.jpg" />
+                  <img src="/repo_images/spoon.jpg" alt="spoon" />
                 </div>
               </li>
               <li class="menu-item">
@@ -162,7 +162,7 @@
                   <p class="menu-item-description">Clean, lightweight protocol buffers for Android and Java.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/wire.jpg" />
+                  <img src="/repo_images/wire.jpg" alt="wire" />
                 </div>
               </li>
               </ol>
@@ -207,7 +207,7 @@
                   <p class="menu-item-description">Square&#x27;s Bitcoin Cold Storage solution.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/subzero.jpg" />
+                  <img src="/repo_images/subzero.jpg" alt="subzero" />
                 </div>
               </li>
               </ol>
@@ -222,7 +222,7 @@
                   <p class="menu-item-description">Utility to audit the balance of Hierarchical Deterministic (HD) wallets. Supports multisig + segwit wallets.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/beancounter.jpg" />
+                  <img src="/repo_images/beancounter.jpg" alt="beancounter" />
                 </div>
               </li>
               <li class="menu-item">
@@ -232,7 +232,7 @@
                   <p class="menu-item-description">Square&#x27;s Bitcoin Cold Storage solution.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/subzero.jpg" />
+                  <img src="/repo_images/subzero.jpg" alt="subzero"/>
                 </div>
               </li>
               </ol>
@@ -298,7 +298,7 @@
                   <p class="menu-item-description">Remote network and data debugging for your native iOS app using Chrome Developer Tools</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/PonyDebugger.jpg" />
+                  <img src="/repo_images/PonyDebugger.jpg" alt="PonyDebugger"/>
                 </div>
               </li>
               <li class="menu-item">
@@ -308,7 +308,7 @@
                   <p class="menu-item-description">Commit fully-formatted Objective-C as a team without even trying.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/spacecommander.jpg" />
+                  <img src="/repo_images/spacecommander.jpg" alt="spacecommander" />
                 </div>
               </li>
               </ol>
@@ -374,7 +374,7 @@
                   <p class="menu-item-description">A modern JSON library for Kotlin and Java.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/moshi.jpg" />
+                  <img src="/repo_images/moshi.jpg" alt="moshi" />
                 </div>
               </li>
               <li class="menu-item">
@@ -384,7 +384,7 @@
                   <p class="menu-item-description">An HTTP client for Android, Kotlin, and Java.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/okhttp.jpg" />
+                  <img src="/repo_images/okhttp.jpg" alt="okhttp" />
                 </div>
               </li>
               <li class="menu-item">
@@ -394,7 +394,7 @@
                   <p class="menu-item-description">A modern I/O library for Android, Kotlin, and Java.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/okio.jpg" />
+                  <img src="/repo_images/okio.jpg" alt="okio"/>
                 </div>
               </li>
               <li class="menu-item">
@@ -404,7 +404,7 @@
                   <p class="menu-item-description">Java client for the Thumbor image service which allows you to build URIs in an expressive fashion using a fluent API.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/pollexor.jpg" />
+                  <img src="/repo_images/pollexor.jpg" alt="pollexor"/>
                 </div>
               </li>
               <li class="menu-item">
@@ -414,7 +414,7 @@
                   <p class="menu-item-description">Type-safe HTTP client for Android and Java by Square, Inc.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/retrofit.jpg" />
+                  <img src="/repo_images/retrofit.jpg" alt="retrofit"/>
                 </div>
               </li>
               <li class="menu-item">
@@ -424,7 +424,7 @@
                   <p class="menu-item-description">Square&#x27;s Bitcoin Cold Storage solution.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/subzero.jpg" />
+                  <img src="/repo_images/subzero.jpg" alt="subzero"/>
                 </div>
               </li>
               <li class="menu-item">
@@ -434,7 +434,7 @@
                   <p class="menu-item-description">Clean, lightweight protocol buffers for Android and Java.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/wire.jpg" />
+                  <img src="/repo_images/wire.jpg" alt="wire"/>
                 </div>
               </li>
               </ol>
@@ -472,7 +472,7 @@
                   <p class="menu-item-description">Fast n-dimensional filtering and grouping of records.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/crossfilter.jpg" />
+                  <img src="/repo_images/crossfilter.jpg" alt="crossfilter" />
                 </div>
               </li>
               <li class="menu-item">
@@ -482,7 +482,7 @@
                   <p class="menu-item-description">Cube: A system for time series visualization.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/cube.jpg" />
+                  <img src="/repo_images/cube.jpg" alt="cube" />
                 </div>
               </li>
               <li class="menu-item">
@@ -492,7 +492,7 @@
                   <p class="menu-item-description">Cubism.js: A JavaScript library for time series visualization.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/cubism.jpg" />
+                  <img src="/repo_images/cubism.jpg" alt="cubism" />
                 </div>
               </li>
               <li class="menu-item">
@@ -502,7 +502,7 @@
                   <p class="menu-item-description">Tomorrow’s JavaScript module syntax today</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/es6-module-transpiler.jpg" />
+                  <img src="/repo_images/es6-module-transpiler.jpg" alt="es6-module-transpiler" />
                 </div>
               </li>
               <li class="menu-item">
@@ -512,7 +512,7 @@
                   <p class="menu-item-description">FieldKit lets you take control of your text fields.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/field-kit.jpg" />
+                  <img src="/repo_images/field-kit.jpg" alt="field-kit"/>
                 </div>
               </li>
               <li class="menu-item">
@@ -522,7 +522,7 @@
                   <p class="menu-item-description">Simple object validation for JavaScript.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/lgtm.jpg" />
+                  <img src="/repo_images/lgtm.jpg" alt="lgtm"/>
                 </div>
               </li>
               </ol>
@@ -546,7 +546,7 @@
                   <p class="menu-item-description">A Kotlin API for generating .kt source files.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/kotlinpoet.jpg" />
+                  <img src="/repo_images/kotlinpoet.jpg" alt="kotlinpoet"/>
                 </div>
               </li>
               <li class="menu-item">
@@ -556,7 +556,7 @@
                   <p class="menu-item-description">LeakCanary is a memory leak detection library for Android.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/leakcanary.jpg" />
+                  <img src="/repo_images/leakcanary.jpg" alt="leakcanary" />
                 </div>
               </li>
               <li class="menu-item">
@@ -566,7 +566,7 @@
                   <p class="menu-item-description">An HTTP client for Android, Kotlin, and Java.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/okhttp.jpg" />
+                  <img src="/repo_images/okhttp.jpg" alt="okhttp"/>
                 </div>
               </li>
               <li class="menu-item">
@@ -576,7 +576,7 @@
                   <p class="menu-item-description">A modern I/O library for Android, Kotlin, and Java.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/okio.jpg" />
+                  <img src="/repo_images/okio.jpg" alt="okio"/>
                 </div>
               </li>
               <li class="menu-item">
@@ -586,7 +586,7 @@
                   <p class="menu-item-description">Type-safe HTTP client for Android and Java by Square, Inc.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/retrofit.jpg" />
+                  <img src="/repo_images/retrofit.jpg" alt="retrofit"/>
                 </div>
               </li>
               <li class="menu-item">
@@ -596,7 +596,7 @@
                   <p class="menu-item-description">Clean, lightweight protocol buffers for Android and Java.</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/wire.jpg" />
+                  <img src="/repo_images/wire.jpg" alt="wire"/>
                 </div>
               </li>
               </ol>
@@ -674,7 +674,7 @@
                   <p class="menu-item-description">String extraction, translation and export tools for the 21st century. &quot;Moving strings around so you don&#x27;t have to&quot;</p>
                 </div>
                 <div class="menu-item-image has-meta-content">
-                  <img src="/repo_images/shuttle.jpg" />
+                  <img src="/repo_images/shuttle.jpg" alt="shuttle" />
                 </div>
               </li>
               </ol>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Square Open Source</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
+    <meta name=”description” content=”As a company built on open source, here are some of the internally-developed libraries we have contributed back to the community.”>
 
     <link href="/assets/base.css" media="screen" rel="stylesheet" type="text/css" />
     <link rel="shortcut icon" href="/assets/public/favicon.ico" />


### PR DESCRIPTION
The accessibility was dangerously low for the site (36 via lighthouse) and thought alt tags would be a good start for the overall accessibility and SEO. 

Added meta description for SEO, it was scoring fairly low as well (78 via lighthouse)

If alt tags should be the images description over hover instead of the name of the repo, I would be more than happy to change them. 