### PR TITLE
Remove google plus icon and link since google plus no longer exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 _site
+.idea/*
+*.iml

--- a/assets/base_expanded.css
+++ b/assets/base_expanded.css
@@ -305,13 +305,6 @@ p {
   height: 40px;
   width: 40px;
 }
-.icon-gplus {
-  background: url('/images/gplus.png') no-repeat;
-  height: 40px;
-  width: 40px;
-  display: inline-block;
-  vertical-align: middle;
-}
 .profile {
   font-size: 0.875em;
   line-height: 1.42857em;

--- a/index.html
+++ b/index.html
@@ -726,7 +726,6 @@
                   <li><a href="https://squareup.com/careers">Careers Page</a> &ndash; squareup.com/careers</li>
                   <li class="module-social">
                     <a href="https://twitter.com/SquareEng" target="_blank"><i class="icon-twitter"></i></a>
-                    <a href="https://plus.google.com/communities/109244258569782858265" target="_blank"><i class="icon-gplus"></i></a>
                   </li>
                 </ul>
               </li>

--- a/index.mustache
+++ b/index.mustache
@@ -101,7 +101,6 @@
                   <li><a href="https://squareup.com/careers">Careers Page</a> &ndash; squareup.com/careers</li>
                   <li class="module-social">
                     <a href="https://twitter.com/SquareEng" target="_blank"><i class="icon-twitter"></i></a>
-                    <a href="https://plus.google.com/communities/109244258569782858265" target="_blank"><i class="icon-gplus"></i></a>
                   </li>
                 </ul>
               </li>


### PR DESCRIPTION
Remove google plus icon and link since google plus no longer exists

I tagged the two contributors who have merged PRs the most recently :) 

<img width="1176" alt="Screen Shot 2020-09-24 at 7 14 18 PM" src="https://user-images.githubusercontent.com/578159/94218895-5bfdcd80-fe9a-11ea-8b07-5b83d8ed870a.png">
<img width="1260" alt="Screen Shot 2020-09-24 at 7 14 09 PM" src="https://user-images.githubusercontent.com/578159/94218897-5d2efa80-fe9a-11ea-84d9-0d8b4b0ae386.png">
<img width="1182" alt="Screen Shot 2020-09-24 at 7 14 00 PM" src="https://user-images.githubusercontent.com/578159/94218898-5d2efa80-fe9a-11ea-9db8-966a9cb8e6d6.png">
